### PR TITLE
Add animated pin markers

### DIFF
--- a/main.js
+++ b/main.js
@@ -3,6 +3,51 @@ const world = Globe()(document.getElementById('globeViz'))
   .globeImageUrl('//unpkg.com/three-globe/example/img/earth-night.jpg')
   .pointOfView({ lat: 0, lng: 0, altitude: 2 });
 
+// Group to hold marker objects
+const markerGroup = new THREE.Group();
+world.scene().add(markerGroup);
+const markers = [];
+
+function createMarker(color) {
+  const mat = new THREE.MeshBasicMaterial({ color });
+  const cone = new THREE.Mesh(new THREE.ConeGeometry(0.2, 0.5, 8), mat);
+  cone.position.y = -0.25;
+  const sphere = new THREE.Mesh(new THREE.SphereGeometry(0.25, 8, 8), mat);
+  const group = new THREE.Group();
+  group.add(cone);
+  group.add(sphere);
+  return group;
+}
+
+function setMarkerPosition(marker, lat, lng, altitude) {
+  const radius = world.getGlobeRadius ? world.getGlobeRadius() : 100;
+  const phi = (90 - lat) * Math.PI / 180;
+  const theta = (lng + 180) * Math.PI / 180;
+  const r = radius * altitude;
+  marker.position.set(
+    r * Math.sin(phi) * Math.cos(theta),
+    r * Math.cos(phi),
+    r * Math.sin(phi) * Math.sin(theta)
+  );
+  marker.lookAt(0, 0, 0);
+}
+
+function clearMarkers() {
+  while (markerGroup.children.length) markerGroup.remove(markerGroup.children[0]);
+  markers.length = 0;
+}
+
+function animateMarkers() {
+  markers.forEach(m => {
+    m.userData.t += 0.02;
+    const alt = 1.02 + 0.02 * Math.sin(m.userData.t);
+    setMarkerPosition(m, m.userData.lat, m.userData.lng, alt);
+    m.rotateZ(0.05);
+  });
+  requestAnimationFrame(animateMarkers);
+}
+animateMarkers();
+
 const info = document.getElementById('info');
 
 // Handle click events
@@ -20,9 +65,22 @@ world.onGlobeClick(({ lat, lng }) => {
         data.address.country ||
         'the ocean';
 
-      world
-        .pointsData([{ lat: antiLat, lng: antiLng, size: 0.5, color: 'red' }])
-        .pointLabel(() => `${location}\n(${antiLat.toFixed(2)}, ${antiLng.toFixed(2)})`);
+      clearMarkers();
+      const clickedMarker = createMarker(0xffff00);
+      clickedMarker.userData = { lat, lng, t: 0 };
+      markerGroup.add(clickedMarker);
+      markers.push(clickedMarker);
+
+      const antipodeMarker = createMarker(0xff0000);
+      antipodeMarker.userData = { lat: antiLat, lng: antiLng, t: Math.PI };
+      markerGroup.add(antipodeMarker);
+      markers.push(antipodeMarker);
+
+      setMarkerPosition(clickedMarker, lat, lng, 1.02);
+      setMarkerPosition(antipodeMarker, antiLat, antiLng, 1.02);
+
+      world.pointsData([]);
+      world.pointLabel(() => `${location}\n(${antiLat.toFixed(2)}, ${antiLng.toFixed(2)})`);
 
       info.textContent = `${location} (${antiLat.toFixed(2)}, ${antiLng.toFixed(2)})`;
     })


### PR DESCRIPTION
## Summary
- display custom markers on click
- animate markers so they bounce and rotate
- add different colored marker for antipodal position

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68757fa01524832b925f20f648d1bd25