### PR TITLE
Add location info for clicks and fix overlay blocking

### DIFF
--- a/style.css
+++ b/style.css
@@ -64,6 +64,7 @@ header nav a {
   border-radius: 4px;
   display: flex;
   gap: 0.5rem;
+  pointer-events: none;
 }
 
 #coord-form input {
@@ -72,6 +73,7 @@ header nav a {
   border: none;
   border-radius: 4px;
   font-size: 1rem;
+  pointer-events: auto;
 }
 
 #coord-form button {
@@ -82,4 +84,5 @@ header nav a {
   color: #fff;
   cursor: pointer;
   font-size: 1rem;
+  pointer-events: auto;
 }


### PR DESCRIPTION
## Summary
- display both the clicked and antipodal locations
- prevent the coordinate form from blocking globe clicks

## Testing
- `node --version`
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_687582b09dbc832bbea4c03288bb49c6