### PR TITLE
Fix ocean country search distance

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@
 <p>Discover the exact point on Earth directly opposite any location with our interactive 3D globe.<br>
 The interface now features a modern dark theme and an on-screen display of antipodal coordinates. You can either click the globe or use the input field at the top to enter latitude and longitude values to pinpoint any location and its exact opposite.</p>
 
-<p>You can also search for a country by name. Selecting a country fills the coordinate fields with its geographic center and automatically finds the antipode. If the selected point or its antipode falls in the ocean, the nearest country is shown next to "Ocean".</p>
+<p>You can also search for a country by name. Selecting a country fills the coordinate fields with its geographic center and automatically finds the antipode. If the selected point or its antipode falls in the ocean, the nearest country (within 200&nbsp;km) is shown next to "Ocean".</p>

--- a/index.html
+++ b/index.html
@@ -306,7 +306,9 @@
       }
     }
 
-    async function nearestCountry(lat, lng) {
+    const NEAR_THRESHOLD_KM = 200;
+
+    async function nearestCountry(lat, lng, threshold = NEAR_THRESHOLD_KM) {
       const data = await countriesDataPromise;
       const pt = turf.point([lng, lat]);
       let min = Infinity;
@@ -319,7 +321,7 @@
           nearest = f.properties.name;
         }
       });
-      return nearest;
+      return min <= threshold ? nearest : null;
     }
 
     async function getCountryFeature(lat, lng) {
@@ -387,14 +389,15 @@
 
       // 지명 정보 업데이트
       Promise.all([reverseGeocode(lat, lng), reverseGeocode(antiLat, antiLng)])
-        .then(async ([clickedLoc, antipodeLoc]) => {
+        .then(async results => {
+          let [clickedLoc, antipodeLoc] = results;
           if (clickedLoc === 'Ocean') {
             const near = await nearestCountry(lat, lng);
-            clickedLoc = `Ocean (near ${near})`;
+            if (near) clickedLoc = `Ocean (near ${near})`;
           }
           if (antipodeLoc === 'Ocean') {
             const near = await nearestCountry(antiLat, antiLng);
-            antipodeLoc = `Ocean (near ${near})`;
+            if (near) antipodeLoc = `Ocean (near ${near})`;
           }
           document.getElementById('clicked-name').textContent = clickedLoc;
           document.getElementById('antipode-name').textContent = antipodeLoc;


### PR DESCRIPTION
## Summary
- limit nearest-country lookup to 200 km
- show 'Ocean' if no nearby country
- clarify README about the 200 km threshold

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6876ca1bfe38832bb961a87cd115f2eb