### PR TITLE
Fix highlight orientation on globe

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,7 +96,36 @@
     import Globe from 'https://esm.sh/globe.gl@2.41.1';
     import * as turf from 'https://esm.sh/@turf/turf@6';
 
-    const countriesDataPromise = fetch('countries.geojson').then(res => res.json());
+    function ringArea(r) {
+      let a = 0;
+      for (let i = 0; i < r.length - 1; i++) {
+        const [x1, y1] = r[i];
+        const [x2, y2] = r[i + 1];
+        a += (x2 - x1) * (y2 + y1);
+      }
+      return a;
+    }
+
+    function fixOrientation(f) {
+      const t = f.geometry.type;
+      const cs = f.geometry.coordinates;
+      const eachRing = (ring, idx) => {
+        const a = ringArea(ring);
+        if ((idx === 0 && a < 0) || (idx > 0 && a > 0)) ring.reverse();
+      };
+      if (t === 'Polygon') {
+        cs.forEach(eachRing);
+      } else if (t === 'MultiPolygon') {
+        cs.forEach(p => p.forEach(eachRing));
+      }
+    }
+
+    const countriesDataPromise = fetch('countries.geojson')
+      .then(res => res.json())
+      .then(data => {
+        data.features.forEach(fixOrientation);
+        return data;
+      });
 
     const countryCentersPromise = (async () => {
       const cached = localStorage.getItem('countryCenters');
@@ -105,7 +134,7 @@
       const centers = {};
       data.features.forEach(f => {
         const c = turf.centroid(f);
-        centers[f.properties.name] = c.geometry.coordinates;
+        centers[f.properties.NAME] = c.geometry.coordinates;
       });
       localStorage.setItem('countryCenters', JSON.stringify(centers));
       return centers;
@@ -300,7 +329,7 @@
         const data = await countriesDataPromise;
         const pt = turf.point([lng, lat]);
         const country = data.features.find(f => turf.booleanPointInPolygon(pt, f));
-        return country ? country.properties.name : 'Ocean';
+        return country ? country.properties.NAME : 'Ocean';
       } catch (e) {
         return 'Unknown location';
       }
@@ -318,7 +347,7 @@
         const dist = turf.pointToLineDistance(pt, line, { units: 'kilometers' });
         if (dist < min) {
           min = dist;
-          nearest = f.properties.name;
+          nearest = f.properties.NAME;
         }
       });
       return min <= threshold ? nearest : null;


### PR DESCRIPTION
## Summary
- ensure geojson polygons have clockwise exterior rings
- use the `NAME` field instead of the non-existent `name` field

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6876d335a5e8832b934c35f08b683264