### PR TITLE
Highlight nearest country for ocean points

### DIFF
--- a/index.html
+++ b/index.html
@@ -162,13 +162,24 @@
     const highlightedCountries = [];
     world.polygonsData(highlightedCountries)
       .polygonAltitude(0.01)
-      .polygonCapColor(d => d.properties._role === 'start'
-        ? 'rgba(245,158,11,0.5)'
-        : 'rgba(239,68,68,0.5)')
+      .polygonCapColor(d => {
+        switch (d.properties._role) {
+          case 'start':
+            return 'rgba(245,158,11,0.5)';
+          case 'start-near':
+            return 'rgba(245,158,11,0.25)';
+          case 'antipode-near':
+            return 'rgba(239,68,68,0.25)';
+          default:
+            return 'rgba(239,68,68,0.5)'; // antipode
+        }
+      })
       .polygonSideColor(() => 'rgba(255,255,255,0.15)')
-      .polygonStrokeColor(d => d.properties._role === 'start'
-        ? '#f59e0b'
-        : '#ef4444');
+      .polygonStrokeColor(d =>
+        d.properties._role === 'start' || d.properties._role === 'start-near'
+          ? '#f59e0b'
+          : '#ef4444'
+      );
 
     // Collapse panel when the user interacts with the globe
     world.controls().addEventListener('start', () => {
@@ -390,6 +401,39 @@
       return nearest;
     }
 
+    async function nearestCountryFeature(lat, lng, threshold = NEAR_THRESHOLD_KM) {
+      const data = await countriesDataPromise;
+      const pt = turf.point([lng, lat]);
+      let minDist = threshold;
+      let nearest = null;
+
+      data.features.forEach(f => {
+        const geom = f.geometry;
+        if (geom.type === 'Polygon') {
+          try {
+            const line = turf.polygonToLine(f);
+            const d = turf.pointToLineDistance(pt, line, { units: 'kilometers' });
+            if (d < minDist) { minDist = d; nearest = f; }
+          } catch (_) { /* skip invalid */ }
+        } else if (geom.type === 'MultiPolygon') {
+          geom.coordinates.forEach(coords => {
+            const polyFeat = {
+              type: 'Feature',
+              geometry: { type: 'Polygon', coordinates: coords },
+              properties: f.properties
+            };
+            try {
+              const line = turf.polygonToLine(polyFeat);
+              const d = turf.pointToLineDistance(pt, line, { units: 'kilometers' });
+              if (d < minDist) { minDist = d; nearest = f; }
+            } catch (_) { /* skip invalid */ }
+          });
+        }
+      });
+
+      return minDist < threshold ? nearest : null;
+    }
+
     async function getCountryFeature(lat, lng) {
       const data = await countriesDataPromise;
       const pt = turf.point([lng, lat]);
@@ -427,16 +471,26 @@
 
       Promise.all([
         getCountryFeature(lat, lng),
-        getCountryFeature(antiLat, antiLng)
-      ]).then(([startF, antiF]) => {
+        getCountryFeature(antiLat, antiLng),
+        nearestCountryFeature(lat, lng),
+        nearestCountryFeature(antiLat, antiLng)
+      ]).then(([startF, antiF, startNear, antiNear]) => {
         if (startF) {
           const c = JSON.parse(JSON.stringify(startF));
           c.properties._role = 'start';
+          highlightedCountries.push(c);
+        } else if (startNear) {
+          const c = JSON.parse(JSON.stringify(startNear));
+          c.properties._role = 'start-near';
           highlightedCountries.push(c);
         }
         if (antiF) {
           const c = JSON.parse(JSON.stringify(antiF));
           c.properties._role = 'antipode';
+          highlightedCountries.push(c);
+        } else if (antiNear) {
+          const c = JSON.parse(JSON.stringify(antiNear));
+          c.properties._role = 'antipode-near';
           highlightedCountries.push(c);
         }
         world.polygonsData(highlightedCountries);


### PR DESCRIPTION
## Summary
- highlight nearby countries when selected location is in the ocean
- draw near pinned country with transparent yellow
- draw near antipode country with transparent red

## Testing
- `npm test` *(fails: cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6876e4bb2130832b967902836b03691e