### PR TITLE
Draw lines to nearest countries

### DIFF
--- a/index.html
+++ b/index.html
@@ -163,13 +163,24 @@
     const highlightedCountries = [];
     world.polygonsData(highlightedCountries)
       .polygonAltitude(0.01)
-      .polygonCapColor(d => d.properties._role === 'start'
-        ? 'rgba(245,158,11,0.5)'
-        : 'rgba(239,68,68,0.5)')
+      .polygonCapColor(d => {
+        switch (d.properties._role) {
+          case 'start':
+            return 'rgba(245,158,11,0.5)';
+          case 'start-near':
+            return 'rgba(245,158,11,0.25)';
+          case 'antipode-near':
+            return 'rgba(239,68,68,0.25)';
+          default:
+            return 'rgba(239,68,68,0.5)'; // antipode
+        }
+      })
       .polygonSideColor(() => 'rgba(255,255,255,0.15)')
-      .polygonStrokeColor(d => d.properties._role === 'start'
-        ? '#f59e0b'
-        : '#ef4444');
+      .polygonStrokeColor(d =>
+        d.properties._role === 'start' || d.properties._role === 'start-near'
+          ? '#f59e0b'
+          : '#ef4444'
+      );
 
     // Collapse panel when the user interacts with the globe
     world.controls().addEventListener('start', () => {
@@ -433,6 +444,39 @@
 
       return nearest;
     }
+
+    async function nearestCountryFeature(lat, lng, threshold = NEAR_THRESHOLD_KM) {
+      const data = await countriesDataPromise;
+      const pt = turf.point([lng, lat]);
+      let minDist = threshold;
+      let nearest = null;
+
+      data.features.forEach(f => {
+        const geom = f.geometry;
+        if (geom.type === 'Polygon') {
+          try {
+            const line = turf.polygonToLine(f);
+            const d = turf.pointToLineDistance(pt, line, { units: 'kilometers' });
+            if (d < minDist) { minDist = d; nearest = f; }
+          } catch (_) { /* skip invalid */ }
+        } else if (geom.type === 'MultiPolygon') {
+          geom.coordinates.forEach(coords => {
+            const polyFeat = {
+              type: 'Feature',
+              geometry: { type: 'Polygon', coordinates: coords },
+              properties: f.properties
+            };
+            try {
+              const line = turf.polygonToLine(polyFeat);
+              const d = turf.pointToLineDistance(pt, line, { units: 'kilometers' });
+              if (d < minDist) { minDist = d; nearest = f; }
+            } catch (_) { /* skip invalid */ }
+          });
+        }
+      });
+
+      return minDist < threshold ? nearest : null;
+    }
     async function nearestCountryPoint(lat, lng, threshold = NEAR_THRESHOLD_KM) {
       const data = await countriesDataPromise;
       const pt = turf.point([lng, lat]);
@@ -509,32 +553,42 @@
         getCountryFeature(lat, lng),
         getCountryFeature(antiLat, antiLng),
         nearestCountryPoint(lat, lng),
-        nearestCountryPoint(antiLat, antiLng)
-      ]).then(([startF, antiF, startNear, antiNear]) => {
-        if (!startF && startNear) {
+        nearestCountryPoint(antiLat, antiLng),
+        nearestCountryFeature(lat, lng),
+        nearestCountryFeature(antiLat, antiLng)
+      ]).then(([startF, antiF, startNearPt, antiNearPt, startNearFeat, antiNearFeat]) => {
+        if (!startF && startNearPt) {
           lineGroup.add(
-            createNearLine(lat, lng, startNear.point[1], startNear.point[0], 0xf59e0b)
+            createNearLine(lat, lng, startNearPt.point[1], startNearPt.point[0], 0xf59e0b)
           );
           labelGroup.add(
-            createDistanceLabel(lat, lng, startNear.point[1], startNear.point[0], startNear.distance)
+            createDistanceLabel(lat, lng, startNearPt.point[1], startNearPt.point[0], startNearPt.distance)
           );
         }
-        if (!antiF && antiNear) {
+        if (!antiF && antiNearPt) {
           lineGroup.add(
-            createNearLine(antiLat, antiLng, antiNear.point[1], antiNear.point[0], 0xef4444)
+            createNearLine(antiLat, antiLng, antiNearPt.point[1], antiNearPt.point[0], 0xef4444)
           );
           labelGroup.add(
-            createDistanceLabel(antiLat, antiLng, antiNear.point[1], antiNear.point[0], antiNear.distance)
+            createDistanceLabel(antiLat, antiLng, antiNearPt.point[1], antiNearPt.point[0], antiNearPt.distance)
           );
         }
         if (startF) {
           const c = JSON.parse(JSON.stringify(startF));
           c.properties._role = 'start';
           highlightedCountries.push(c);
+        } else if (startNearFeat) {
+          const c = JSON.parse(JSON.stringify(startNearFeat));
+          c.properties._role = 'start-near';
+          highlightedCountries.push(c);
         }
         if (antiF) {
           const c = JSON.parse(JSON.stringify(antiF));
           c.properties._role = 'antipode';
+          highlightedCountries.push(c);
+        } else if (antiNearFeat) {
+          const c = JSON.parse(JSON.stringify(antiNearFeat));
+          c.properties._role = 'antipode-near';
           highlightedCountries.push(c);
         }
         world.polygonsData(highlightedCountries);

--- a/index.html
+++ b/index.html
@@ -95,6 +95,7 @@
     import * as THREE from 'https://esm.sh/three@0.153.0';
     import Globe from 'https://esm.sh/globe.gl@2.41.1';
     import * as turf from 'https://esm.sh/@turf/turf@6';
+    import SpriteText from 'https://esm.sh/three-spritetext@2';
 
     function ringArea(r) {
       let a = 0;
@@ -162,24 +163,13 @@
     const highlightedCountries = [];
     world.polygonsData(highlightedCountries)
       .polygonAltitude(0.01)
-      .polygonCapColor(d => {
-        switch (d.properties._role) {
-          case 'start':
-            return 'rgba(245,158,11,0.5)';
-          case 'start-near':
-            return 'rgba(245,158,11,0.25)';
-          case 'antipode-near':
-            return 'rgba(239,68,68,0.25)';
-          default:
-            return 'rgba(239,68,68,0.5)'; // antipode
-        }
-      })
+      .polygonCapColor(d => d.properties._role === 'start'
+        ? 'rgba(245,158,11,0.5)'
+        : 'rgba(239,68,68,0.5)')
       .polygonSideColor(() => 'rgba(255,255,255,0.15)')
-      .polygonStrokeColor(d =>
-        d.properties._role === 'start' || d.properties._role === 'start-near'
-          ? '#f59e0b'
-          : '#ef4444'
-      );
+      .polygonStrokeColor(d => d.properties._role === 'start'
+        ? '#f59e0b'
+        : '#ef4444');
 
     // Collapse panel when the user interacts with the globe
     world.controls().addEventListener('start', () => {
@@ -194,6 +184,8 @@
     world.scene().add(markerGroup);
     const lineGroup = new THREE.Group();
     world.scene().add(lineGroup);
+    const labelGroup = new THREE.Group();
+    world.scene().add(labelGroup);
     const markers = [];
 
     // 마커 생성 함수 (개선된 디자인)
@@ -253,6 +245,43 @@
       line.computeLineDistances();
       return line;
     }
+    function createNearLine(lat1, lng1, lat2, lng2, color) {
+      const a = world.getCoords(lat1, lng1, 0.1);
+      const b = world.getCoords(lat2, lng2, 0.1);
+      const pts = [
+        new THREE.Vector3(a.x, a.y, a.z),
+        new THREE.Vector3(b.x, b.y, b.z)
+      ];
+      const geom = new THREE.BufferGeometry().setFromPoints(pts);
+      const mat = new THREE.LineDashedMaterial({
+        color,
+        dashSize: 1,
+        gapSize: 0.5,
+        opacity: 0.8,
+        transparent: true,
+        linewidth: 2
+      });
+      const line = new THREE.Line(geom, mat);
+      line.computeLineDistances();
+      return line;
+    }
+
+    function createDistanceLabel(lat1, lng1, lat2, lng2, distance) {
+      const a = world.getCoords(lat1, lng1, 0.1);
+      const b = world.getCoords(lat2, lng2, 0.1);
+      const mid = {
+        x: (a.x + b.x) / 2,
+        y: (a.y + b.y) / 2,
+        z: (a.z + b.z) / 2
+      };
+      const label = new SpriteText(`${distance.toFixed(0)} km`);
+      label.color = '#ffffff';
+      label.textHeight = 2;
+      label.material.depthWrite = false;
+      label.position.set(mid.x, mid.y, mid.z);
+      return label;
+    }
+
 
     function clearMarkers() {
       markerGroup.clear();
@@ -261,6 +290,10 @@
 
     function clearLines() {
       lineGroup.clear();
+    }
+
+    function clearLabels() {
+      labelGroup.clear();
     }
 
     // 개선된 마커 애니메이션
@@ -400,38 +433,40 @@
 
       return nearest;
     }
-
-    async function nearestCountryFeature(lat, lng, threshold = NEAR_THRESHOLD_KM) {
+    async function nearestCountryPoint(lat, lng, threshold = NEAR_THRESHOLD_KM) {
       const data = await countriesDataPromise;
       const pt = turf.point([lng, lat]);
       let minDist = threshold;
       let nearest = null;
-
+      let nearestPt = null;
       data.features.forEach(f => {
         const geom = f.geometry;
-        if (geom.type === 'Polygon') {
+        if (geom.type === "Polygon") {
           try {
             const line = turf.polygonToLine(f);
-            const d = turf.pointToLineDistance(pt, line, { units: 'kilometers' });
-            if (d < minDist) { minDist = d; nearest = f; }
-          } catch (_) { /* skip invalid */ }
-        } else if (geom.type === 'MultiPolygon') {
+            const snapped = turf.nearestPointOnLine(line, pt, { units: "kilometers" });
+            if (snapped.properties.dist < minDist) {
+              minDist = snapped.properties.dist;
+              nearest = f;
+              nearestPt = snapped.geometry.coordinates;
+            }
+          } catch (_) { }
+        } else if (geom.type === "MultiPolygon") {
           geom.coordinates.forEach(coords => {
-            const polyFeat = {
-              type: 'Feature',
-              geometry: { type: 'Polygon', coordinates: coords },
-              properties: f.properties
-            };
+            const polyFeat = { type: "Feature", geometry: { type: "Polygon", coordinates: coords }, properties: f.properties };
             try {
               const line = turf.polygonToLine(polyFeat);
-              const d = turf.pointToLineDistance(pt, line, { units: 'kilometers' });
-              if (d < minDist) { minDist = d; nearest = f; }
-            } catch (_) { /* skip invalid */ }
+              const snapped = turf.nearestPointOnLine(line, pt, { units: "kilometers" });
+              if (snapped.properties.dist < minDist) {
+                minDist = snapped.properties.dist;
+                nearest = f;
+                nearestPt = snapped.geometry.coordinates;
+              }
+            } catch (_) { }
           });
         }
       });
-
-      return minDist < threshold ? nearest : null;
+      return minDist < threshold ? { feature: nearest, point: nearestPt, distance: minDist } : null;
     }
 
     async function getCountryFeature(lat, lng) {
@@ -452,6 +487,7 @@
       clearMarkers();
       clearLines();
       highlightedCountries.length = 0;
+      clearLabels();
       world.polygonsData(highlightedCountries);
 
       // 마커 생성
@@ -472,25 +508,33 @@
       Promise.all([
         getCountryFeature(lat, lng),
         getCountryFeature(antiLat, antiLng),
-        nearestCountryFeature(lat, lng),
-        nearestCountryFeature(antiLat, antiLng)
+        nearestCountryPoint(lat, lng),
+        nearestCountryPoint(antiLat, antiLng)
       ]).then(([startF, antiF, startNear, antiNear]) => {
+        if (!startF && startNear) {
+          lineGroup.add(
+            createNearLine(lat, lng, startNear.point[1], startNear.point[0], 0xf59e0b)
+          );
+          labelGroup.add(
+            createDistanceLabel(lat, lng, startNear.point[1], startNear.point[0], startNear.distance)
+          );
+        }
+        if (!antiF && antiNear) {
+          lineGroup.add(
+            createNearLine(antiLat, antiLng, antiNear.point[1], antiNear.point[0], 0xef4444)
+          );
+          labelGroup.add(
+            createDistanceLabel(antiLat, antiLng, antiNear.point[1], antiNear.point[0], antiNear.distance)
+          );
+        }
         if (startF) {
           const c = JSON.parse(JSON.stringify(startF));
           c.properties._role = 'start';
-          highlightedCountries.push(c);
-        } else if (startNear) {
-          const c = JSON.parse(JSON.stringify(startNear));
-          c.properties._role = 'start-near';
           highlightedCountries.push(c);
         }
         if (antiF) {
           const c = JSON.parse(JSON.stringify(antiF));
           c.properties._role = 'antipode';
-          highlightedCountries.push(c);
-        } else if (antiNear) {
-          const c = JSON.parse(JSON.stringify(antiNear));
-          c.properties._role = 'antipode-near';
           highlightedCountries.push(c);
         }
         world.polygonsData(highlightedCountries);


### PR DESCRIPTION
## Summary
- revert incorrect distance label feature and related changes
- compute closest country boundary when click/antipode falls in ocean
- draw dashed lines from the point to the nearest country's edge
- show distance labels on the main globe

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6876e5faada8832b818dbbb71ef8124e