### PR TITLE
Improve near line path and label placement

### DIFF
--- a/index.html
+++ b/index.html
@@ -257,12 +257,11 @@
       return line;
     }
     function createNearLine(lat1, lng1, lat2, lng2, color) {
-      const a = world.getCoords(lat1, lng1, 0.01);
-      const b = world.getCoords(lat2, lng2, 0.01);
-      const pts = [
-        new THREE.Vector3(a.x, a.y, a.z),
-        new THREE.Vector3(b.x, b.y, b.z)
-      ];
+      const gc = turf.greatCircle([lng1, lat1], [lng2, lat2], { npoints: 64 });
+      const pts = gc.geometry.coordinates.map(([lng, lat]) => {
+        const { x, y, z } = world.getCoords(lat, lng, 0.01);
+        return new THREE.Vector3(x, y, z);
+      });
       const geom = new THREE.BufferGeometry().setFromPoints(pts);
       const mat = new THREE.LineDashedMaterial({
         color,
@@ -278,18 +277,13 @@
     }
 
     function createDistanceLabel(lat1, lng1, lat2, lng2, distance) {
-      const a = world.getCoords(lat1, lng1, 0.1);
-      const b = world.getCoords(lat2, lng2, 0.1);
-      const mid = {
-        x: (a.x + b.x) / 2,
-        y: (a.y + b.y) / 2,
-        z: (a.z + b.z) / 2
-      };
+      const mid = turf.midpoint([lng1, lat1], [lng2, lat2]).geometry.coordinates;
+      const { x, y, z } = world.getCoords(mid[1], mid[0], 0.015);
       const label = new SpriteText(`${distance.toFixed(0)} km`);
       label.color = '#ffffff';
       label.textHeight = 2;
       label.material.depthWrite = false;
-      label.position.set(mid.x, mid.y, mid.z);
+      label.position.set(x, y, z);
       return label;
     }
 


### PR DESCRIPTION
## Summary
- curve near lines along the globe surface
- position distance labels close to the ground

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6876ef36b258832b853228bb63cd1e12