### PR TITLE
Fix blocked clicks over highlighted countries

### DIFF
--- a/index.html
+++ b/index.html
@@ -645,6 +645,11 @@
     world.onGlobeRightClick(({ lat, lng }) => {
       showAntipode(lat, lng);
     });
+    world.onPolygonRightClick((_, c) => {
+      if (c && typeof c.lat === 'number' && typeof c.lng === 'number') {
+        showAntipode(c.lat, c.lng);
+      }
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- handle `onPolygonRightClick` so right-clicks on highlighted countries work the same as the globe

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6876f843fc28832bab2cdaa390ecca08